### PR TITLE
Dropping to net standard 1.1 for compatibility purposes.

### DIFF
--- a/FuzzyString/FuzzyString.csproj
+++ b/FuzzyString/FuzzyString.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>FuzzyString</PackageId>
     <PackageLicenseUrl>./Resources/License.txt</PackageLicenseUrl>


### PR DESCRIPTION
The only reason I couldn't drop down to netstandard 1.0 is because of the GuidAttribute being used in AssemblyInfo.cs